### PR TITLE
kubernetes upgrade 1.16.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,15 +10,15 @@ flannel-v0.11.0-44-g3f87efc4-windows-amd64.tar.gz:
   size: 9548976
   object_id: 1a947dbf-c668-4e34-63c8-63d1aaa715d4
   sha: 7c68f433e4aac88210110df1d0596ee6b46f6157
-kubernetes-windows-1.15.5/kube-proxy.exe:
-  size: 40085504
-  object_id: 7e00e997-18d8-43cb-73dc-c0ccdb10a75f
-  sha: 790dcc599087631b4c10acd595ae6149330ae02e
-kubernetes-windows-1.15.5/kubectl.exe:
-  size: 43478016
-  object_id: 4309d9e5-1e82-4ce5-6ff4-3eeb000d87e6
-  sha: 56dd3ec125436b3a0bc6a6f4c753648256fccf35
-kubernetes-windows-1.15.5/kubelet.exe:
-  size: 116271104
-  object_id: 115f4d7a-85b3-4f5f-5de9-940be54870b5
-  sha: 3a6a8b8ff2f1e28ffad2aaf06c95ed66509971af
+kubernetes-windows-1.16.4/kube-proxy.exe:
+  size: 45661184
+  object_id: c7bbcf0f-2add-4ee9-6ee7-0a39abaef86e
+  sha: dd91a7a770cc84b2103410844f1d3be1af2911cd
+kubernetes-windows-1.16.4/kubectl.exe:
+  size: 47195136
+  object_id: cbd9b1a2-8179-4784-4618-ea065b76f698
+  sha: 2098b877c1aecde9d46ff4126a2e748c7f4f2662
+kubernetes-windows-1.16.4/kubelet.exe:
+  size: 119127552
+  object_id: 397329e0-d36e-471f-691b-8f27d94af467
+  sha: db1aa6fc5d5e8e7e6c018006d8c4d339180a0d26

--- a/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
+++ b/jobs/flanneld-windows/templates/bin/flanneld_ctl.ps1.erb
@@ -34,6 +34,7 @@ function start_flanneld {
   mkdir -force /etc/cni/net.d
   $confFile= '
 {
+  "cniVersion":  "0.2.0",
   "name": "<%= get_network_name %>",
   "plugins": [
     {

--- a/packages/kubernetes-windows/packaging
+++ b/packages/kubernetes-windows/packaging
@@ -3,7 +3,7 @@
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
-$KUBERNETES_VERSION="1.15.5"
+$KUBERNETES_VERSION="1.16.4"
 
 New-Item -Path "${env:BOSH_INSTALL_TARGET}" -Name "bin" -ItemType "directory"
 

--- a/packages/kubernetes-windows/spec
+++ b/packages/kubernetes-windows/spec
@@ -2,5 +2,5 @@
 name: kubernetes-windows
 
 files:
-- kubernetes-windows-1.15.5/*
+- kubernetes-windows-1.16.4/*
 - exiter.ps1


### PR DESCRIPTION
Upgrade kubernetes to 1.16.4. Source is K8s upstream (not common core--they do not yet support windows)

* Also add `cni` version to flannel config, as required for this K8s.