### PR TITLE
Update kube-proxy-windows to accept file arguments

### DIFF
--- a/jobs/kube-proxy-windows/spec
+++ b/jobs/kube-proxy-windows/spec
@@ -3,9 +3,11 @@ name: kube-proxy-windows
 
 templates:
   bin/kube_proxy_ctl.ps1.erb: bin/kube_proxy_ctl.ps1
+  bin/pre-start.ps1: bin/pre-start.ps1
   config/kubeconfig.erb: config/kubeconfig
   config/config.yml.erb: config/config.yml
   config/ca.pem.erb: config/ca.pem
+  config/file-arguments.json.erb: config/file-arguments.json
 
 packages:
 - kubernetes-windows
@@ -36,6 +38,11 @@ properties:
           CPUManager: true
           DryRun: false
         cleanup: false
+  file-arguments:
+    description: "Pass-through options for Kubernetes runtime arguments which accept local file paths as inputs. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ for reference."
+    example: |
+      file-arguments:
+        azure-container-registry-config: base64 encoded config
   cni_init_file:
     description: "File used by kube-proxy to check if cni is initialized"
     default: "/run/flannel/subnet.env"

--- a/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
+++ b/jobs/kube-proxy-windows/templates/bin/kube_proxy_ctl.ps1.erb
@@ -11,7 +11,18 @@ function start_kube_proxy {
   $network = Get-HnsNetwork | ? Type -Eq <%= p('hns_network_type') %>
   $env:KUBE_NETWORK = $network.Name
 
-  C:\var\vcap\packages\kubernetes-windows\bin\kube-proxy.exe -v 5 --config /var/vcap/jobs/kube-proxy-windows/config/config.yml
+  C:\var\vcap\packages\kubernetes-windows\bin\kube-proxy.exe `
+  <%-
+    if_p('file-arguments') do |args|
+      args.each do |flag, content|
+      fileName = "/var/vcap/jobs/kube-proxy-window/config/"+flag
+  -%>
+    <%= "--#{flag}=#{fileName}" %> `
+  <%-
+      end
+    end
+  -%>
+  -v 5 --config /var/vcap/jobs/kube-proxy-windows/config/config.yml
 }
 
 function check_for_networking {

--- a/jobs/kube-proxy-windows/templates/bin/pre-start.ps1
+++ b/jobs/kube-proxy-windows/templates/bin/pre-start.ps1
@@ -1,0 +1,11 @@
+# Reads file-arguments.json, decodes base64 encoded values
+# and writes the output to a file named after the associated key.
+$base_path = 'C:\var\vcap\jobs\kube-proxy-windows'
+$file_args_dict = Get-Content "$base_path\config\file-arguments.json" | Out-String | ConvertFrom-Json
+
+$properties = $file_args_dict | Get-Member -MemberType Properties | Select-Object -ExpandProperty Name
+
+foreach($property in $properties) {
+    $decoded = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($file_args_dict."$property"))
+    $decoded | Out-File -FilePath "$base_path\config\$property"
+}

--- a/jobs/kube-proxy-windows/templates/config/file-arguments.json.erb
+++ b/jobs/kube-proxy-windows/templates/config/file-arguments.json.erb
@@ -1,0 +1,11 @@
+<%
+  require 'json'
+
+  file_args = {}
+  if_p('file-arguments') do |args|
+    args.each do |flag, content|
+      file_args[flag] = content
+    end
+  end
+%>
+<%= file_args.to_json %>


### PR DESCRIPTION
This change updates the kube-proxy-windows job to support file arguments.